### PR TITLE
Updated gitignore file to ignore helpcontext.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -809,4 +809,7 @@ $RECYCLE.BIN/
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
 
+# HelpContext.cs
+
+
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,v


### PR DESCRIPTION
Updated gitignore file to ignore helpcontext.cs

![image](https://github.com/Billy-McCleese/Help_FinalProject/assets/85238378/cba68f89-ee37-43d2-bbaf-eb4977ce686d)
